### PR TITLE
Use device major release version number as hour digit in demo mode clock

### DIFF
--- a/app/src/main/java/xyz/mustafaali/devqstiles/service/ToggleDemoModeService.java
+++ b/app/src/main/java/xyz/mustafaali/devqstiles/service/ToggleDemoModeService.java
@@ -1,6 +1,7 @@
 package xyz.mustafaali.devqstiles.service;
 
 import android.content.Intent;
+import android.os.Build;
 import android.provider.Settings;
 
 /**
@@ -69,7 +70,7 @@ public class ToggleDemoModeService extends BaseTileService {
         sendBroadcast(intent);
 
         intent.putExtra(DemoMode.EXTRA_COMMAND, DemoMode.COMMAND_CLOCK);
-        intent.putExtra("hhmm", "0500");
+        intent.putExtra("hhmm", getDeviceVersionForDemoClock());
         sendBroadcast(intent);
 
         intent.putExtra(DemoMode.EXTRA_COMMAND, DemoMode.COMMAND_NETWORK);
@@ -101,6 +102,10 @@ public class ToggleDemoModeService extends BaseTileService {
         sendBroadcast(intent);
 
         setGlobal(DEMO_MODE_ON, 1);
+    }
+
+    private String getDeviceVersionForDemoClock() {
+        return String.format("0%s00", Build.VERSION.RELEASE.substring(0,1));
     }
 
     private void stopDemoMode() {


### PR DESCRIPTION
Modified demo mode time to be consistent with stock behavior. Google uses uses the major release version digit as the hours value in demo mode clocks. I implemented their format and wanted to share the minor change with you.

Tested on Nexus 6P running 7.1.1.

#### Before (hard-coded)
![hard_coded_clock](https://cloud.githubusercontent.com/assets/819901/21706260/be98afea-d393-11e6-8a67-e04e22531aff.png)

#### After (version-based)
![clock_by_version](https://cloud.githubusercontent.com/assets/819901/21706265/c263dcda-d393-11e6-9e71-b920bff9976c.png)